### PR TITLE
Export a CamelRegistry where clients can register beans

### DIFF
--- a/examples/camel-route/src/config/module.conf
+++ b/examples/camel-route/src/config/module.conf
@@ -1,2 +1,7 @@
 port=${sshdPort}
 knownHostsFile=${sshdKnownHostsFile}
+
+jdbcDriverClass=org.h2.Driver
+helloDatabaseUsername=admin
+helloDatabasePassword=password
+helloDatabaseUrl=jdbc:h2:tcp://localhost:${h2Port}/mem:customers;MODE=Oracle

--- a/examples/camel-route/src/test/database/customers/customers.sql
+++ b/examples/camel-route/src/test/database/customers/customers.sql
@@ -1,0 +1,7 @@
+
+create table customer (
+  username varchar2(30) primary KEY ,
+  name varchar2(50)
+);
+
+INSERT INTO customer (username, name) VALUES ('JOE', 'Joe Doe');

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -247,6 +247,11 @@
                                         <artifactId>camel-ftp</artifactId>
                                         <version>${camel.version}</version>
                                     </dependency>
+                                    <dependency>
+                                        <groupId>org.apache.camel</groupId>
+                                        <artifactId>camel-jdbc</artifactId>
+                                        <version>${camel.version}</version>
+                                    </dependency>
                                 </dependencies>
                             </plugin>
                             <plugin>

--- a/plugins/core/camel/src/main/java/org/kantega/respiro/camel/CamelPlugin.java
+++ b/plugins/core/camel/src/main/java/org/kantega/respiro/camel/CamelPlugin.java
@@ -19,6 +19,7 @@ package org.kantega.respiro.camel;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.SimpleRegistry;
 import org.kantega.respiro.api.DataSourceInitializer;
 import org.kantega.reststop.api.Export;
 import org.kantega.reststop.api.Plugin;
@@ -37,7 +38,11 @@ public class CamelPlugin implements CamelRouteDeployer {
 
     private CamelContext camelContext;
 
+    private SimpleRegistry simpleRegistry = new SimpleRegistry();
+
     @Export final CamelRouteDeployer camelRouteDeployer = this;
+
+    @Export final CamelRegistry camelRegistry = new SimpleCamelRegistry(simpleRegistry);
 
     public CamelPlugin(Collection<DataSourceInitializer> dataSourceInitializers, Collection<CamelContextCustomizer> camelContextCustomizers) throws Exception {
         this.dataSourceInitializers = dataSourceInitializers;
@@ -47,7 +52,7 @@ public class CamelPlugin implements CamelRouteDeployer {
     @Override
     public void deploy(Collection<RouteBuilder> routeBuilders) {
         try {
-            camelContext = new DefaultCamelContext();
+            camelContext = new DefaultCamelContext(simpleRegistry);
 
             camelContextCustomizers.forEach(c -> c.customize(camelContext));
 
@@ -64,6 +69,24 @@ public class CamelPlugin implements CamelRouteDeployer {
     public void stop() throws Exception {
         camelContext.stop();
 
+    }
+
+    private class SimpleCamelRegistry implements CamelRegistry {
+        private final SimpleRegistry simpleRegistry;
+
+        public SimpleCamelRegistry(SimpleRegistry simpleRegistry) {
+            this.simpleRegistry = simpleRegistry;
+        }
+
+        @Override
+        public void add(String name, Object component) {
+            simpleRegistry.put(name, component);
+        }
+
+        @Override
+        public void remove(String name) {
+            simpleRegistry.remove(name);
+        }
     }
 }
 

--- a/plugins/core/camel/src/main/java/org/kantega/respiro/camel/CamelRegistry.java
+++ b/plugins/core/camel/src/main/java/org/kantega/respiro/camel/CamelRegistry.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Kantega AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kantega.respiro.camel;
+
+/**
+ *
+ */
+public interface CamelRegistry {
+
+    void add(String name, Object component);
+    void remove(String name);
+}


### PR DESCRIPTION
Address issue #3 by exporting a CamelRegistry which can be used by clients to register/remove beans from the CamelContext bean registry. 

CamelPlugin now @Export's a CamelRegistry (an interface with add/remove methods for beans).

Clients can use this registry to make beans available to Camel, such as DataSources for the jdbc component.

See an example of using this in CamelRouteDemo.java.