### PR TITLE
Minor upgrades to camel and h2 database configuration

### DIFF
--- a/examples/hello-rest/pom.xml
+++ b/examples/hello-rest/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.176</version>
+            <version>${h2database.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/hello-rest/pom.xml
+++ b/examples/hello-rest/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.190</version>
+            <version>1.3.176</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/core/camel/pom.xml
+++ b/plugins/core/camel/pom.xml
@@ -63,7 +63,7 @@
 
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-quartz</artifactId>
+            <artifactId>camel-quartz2</artifactId>
             <version>${camel.version}</version>
         </dependency>
     </dependencies>

--- a/plugins/core/camel/pom.xml
+++ b/plugins/core/camel/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>respiro-camel-plugin</artifactId>
 
     <properties>
-        <camel.version>2.16.0</camel.version>
+        <camel.version>2.17.0</camel.version>
     </properties>
     <dependencies>
 

--- a/plugins/core/jdbc/pom.xml
+++ b/plugins/core/jdbc/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.176</version>
+            <version>${h2database.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>

--- a/plugins/core/jdbc/pom.xml
+++ b/plugins/core/jdbc/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.190</version>
+            <version>1.3.176</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>

--- a/plugins/test/test-database/pom.xml
+++ b/plugins/test/test-database/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.176</version>
+            <version>${h2database.version}</version>
         </dependency>
     </dependencies>
 

--- a/plugins/test/test-database/pom.xml
+++ b/plugins/test/test-database/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.190</version>
+            <version>1.3.176</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <camel.version>2.16.0</camel.version>
         <activemq.version>5.12.1</activemq.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <h2database.version>1.4.190</h2database.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Minor change to camel plugin. 
Dependency to quartz upgraded to quartz2 and is not compatible with previous versions using "quartz:...." endpoint definitions.
Updated to latest camel release (1.17.0)
Parameterized h2database version 
